### PR TITLE
纠正postProcessMergedBeanDefinition方法的执行时机的描述

### DIFF
--- a/note/spring-context.md
+++ b/note/spring-context.md
@@ -570,7 +570,7 @@ private static final Callback[] CALLBACKS = new Callback[] {
 
 ##### 入口
 
-其中前者首先被调用，时机是当BeanDefinition被合并(和父Bean)，但是还没有用来创建Bean实例时。回顾下其调用入口:
+其中前者首先被调用，时机是已创建Bean实例但还没有对实例执行初始化操作。回顾下其调用入口:
 
 AbstractAutowireCapableBeanFactory.doCreateBean(简略):
 


### PR DESCRIPTION
纠正MergedBeanDefinitionPostProcessor.postProcessMergedBeanDefinition方法的执行时机的描述
```java
protected Object doCreateBean(final String beanName, final RootBeanDefinition mbd, final Object[] args) {
    // Instantiate the bean.
    BeanWrapper instanceWrapper = null;
    if (mbd.isSingleton()) {
        instanceWrapper = this.factoryBeanInstanceCache.remove(beanName);
    }
    if (instanceWrapper == null) {

        //createBeanInstance方法已经创建了实例
        instanceWrapper = createBeanInstance(beanName, mbd, args);
    }
    final Object bean = (instanceWrapper != null ? instanceWrapper.getWrappedInstance() : null);
    Class<?> beanType = (instanceWrapper != null ? instanceWrapper.getWrappedClass() : null);
    // Allow post-processors to modify the merged bean definition.
    synchronized (mbd.postProcessingLock) {
        if (!mbd.postProcessed) {
            applyMergedBeanDefinitionPostProcessors(mbd, beanType, beanName);
            mbd.postProcessed = true;
        }
    }
}	
```
代码中createBeanInstance方法已经创建了实例